### PR TITLE
Do not set isNode to true under bundlers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,10 @@
 
 const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
-const isNode = typeof module !== 'undefined' && typeof module.exports !== 'undefined';
+const isNode =
+  typeof process !== 'undefined' &&
+  process.versions != null &&
+  process.versions.node != null;
 
 export {
   isBrowser,


### PR DESCRIPTION
When using this library under [Parcel](https://parceljs.org/), `isNode` is true even inside the browser. This is probably true for Webpack and other bundlers as well, since they all emulate the `module` system.

This version checks for `process.versions.node`, which is defined on ever version of Node since 0.2.0.

Tested under both Parcel and Node.