### PR TITLE
Add Web Worker support (fix #3)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test
+browser-test

--- a/browser-test/index.html
+++ b/browser-test/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Web Workers test</title>
+  </head>
+  <body>
+    <h1>Browser Test</h1>
+    <textarea id="console" style="width:50em;height:20em;"></textarea>
+
+    <script src="index.js" type="module"></script>
+  </body>
+</html>

--- a/browser-test/index.js
+++ b/browser-test/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+import { isBrowser, isWebWorker, isNode } from './browser-or-node.js';
+
+console.log = (message) => {
+	document.getElementById('console').value += message + '\n';
+}
+
+console.log('Web page reports:');
+console.log('  isBrowser: ' + isBrowser);
+console.log('  isWebWorker: ' + isWebWorker);
+console.log('  isNode: ' + isNode);
+
+if (window.Worker) {
+	const myWorker = new Worker("worker.js");
+
+	myWorker.onmessage = function(e) {
+		let res = e.data;
+		console.log('Web worker reports:');
+		console.log('  isBrowser: ' + e.data[0]);
+		console.log('  isWebWorker: ' + e.data[1]);
+		console.log('  isNode: ' + e.data[2]);
+	}
+	myWorker.postMessage(['Report, please']);
+
+} else {
+	console.log('Your browser doesn\'t support web workers.')
+}

--- a/browser-test/package.json
+++ b/browser-test/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "browser-or-node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "author": "Daniel Wang",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.16.4",
+    "path": "^0.12.7"
+  }
+}

--- a/browser-test/server.js
+++ b/browser-test/server.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+
+// app.use(express.static(path.join(__dirname, 'public')));
+// app.use('/static', express.static(path.join(__dirname, 'public')));
+
+app.get('/', function(req, res) {
+    res.sendFile(path.join(__dirname + '/index.html'));
+});
+
+app.get('/worker.js', function(req, res) {
+    res.sendFile(path.join(__dirname + '/worker.js'));
+});
+
+/*
+app.get('/worker.js', function(req, res) {
+    res.sendFile(path.join(__dirname + '../../src/index.js'));
+});
+*/
+app.get('/index.js', function(req, res) {
+    res.sendFile(path.join(__dirname + '/index.js'));
+});
+
+app.get('/browser-or-node.js', function(req, res) {
+    res.sendFile(path.join(__dirname + '../../src/index.js'));
+});
+
+app.listen(3000, () => {
+  console.log('http://localhost:3000');
+});

--- a/browser-test/worker.js
+++ b/browser-test/worker.js
@@ -1,4 +1,8 @@
-/* global window self */
+// HELP!
+// self.importScripts(...) imports the script, but then Chrome throws
+// an error on export {...} syntax
+
+// self.importScripts('browser-or-node.js');
 
 const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
@@ -14,8 +18,6 @@ const isNode =
   process.versions != null &&
   process.versions.node != null;
 
-export {
-  isBrowser,
-  isWebWorker,
-  isNode
-};
+onmessage = function(e) {
+  postMessage( [isBrowser, isWebWorker, isNode] );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-or-node",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Check where the code is running in the browser or node.js",
   "main": "./lib/index.js",
   "scripts": {
@@ -31,6 +31,9 @@
     "is browser node"
   ],
   "author": "Dineshkumar Pandiyan <flexdinesh@gmail.com>",
+  "contributors": [
+    "Daniel Wang <daniel.liberated@gmail.com> (https://github.com/dan1wang/)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/flexdinesh/browser-or-node/issues"

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
 import { assert } from 'chai';
-import { isBrowser, isNode } from '../src';
+import { isBrowser, isWebBrowser, isNode } from '../src';
+
+console.log(isNode);
 
 describe('Browser or Node.js', () => {
 
@@ -10,6 +12,10 @@ describe('Browser or Node.js', () => {
   it('should check browser env', () => {
     //should figure out how to automate this
     assert(isBrowser === false, 'isBrowser didn\'t work :(');
+  });
+
+  it('should check web worker env', () => {
+    assert(isNode === true, 'isWebWorker didn\'t work :(');
   });
 
 });


### PR DESCRIPTION
Checks for Web Worker.

Can't just import the script. The browser would choke on `export {...}` (ES6 module isn't quite available in Web Worker). So need to either paste the code directly in the worker script, or remove the `export` code in the browser-or-node script

Test OK on Chrome. Haven't done any test on Edge or Firefox.

What's next? Service Worker support?