### PR TITLE
Fix for React Native

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const isWebWorker =
 const isJsDom =
   (typeof window !== "undefined" && window.name === "nodejs") ||
   (typeof navigator !== "undefined" &&
+    typeof navigator.userAgent !== "undefined" &&
     (navigator.userAgent.includes("Node.js") ||
       navigator.userAgent.includes("jsdom")));
 


### PR DESCRIPTION
Fix for Jest tests with React Native, where `navigator.userAgent === undefined`.
